### PR TITLE
use nt service mssqlserver for svc acct

### DIFF
--- a/main.ps1
+++ b/main.ps1
@@ -75,7 +75,7 @@ if ("sqlengine" -in $Install) {
       Invoke-WebRequest -Uri https://download.microsoft.com/download/7/c/1/7c14e92e-bdcb-4f89-b7cf-93543e7112d1/SQLServer2019-DEV-x64-ENU.exe -OutFile sqlsetup.exe
       Invoke-WebRequest -Uri https://download.microsoft.com/download/7/c/1/7c14e92e-bdcb-4f89-b7cf-93543e7112d1/SQLServer2019-DEV-x64-ENU.box -OutFile sqlsetup.box
       Start-Process -Wait -FilePath ./sqlsetup.exe -ArgumentList /qs, /x:setup
-      .\setup\setup.exe /q /ACTION=Install /INSTANCENAME=MSSQLSERVER /FEATURES=SQLEngine /UPDATEENABLED=0 /SQLSVCACCOUNT='NT AUTHORITY\SYSTEM' /SQLSYSADMINACCOUNTS='BUILTIN\ADMINISTRATORS' /TCPENABLED=1 /NPENABLED=0 /IACCEPTSQLSERVERLICENSETERMS
+      .\setup\setup.exe /q /ACTION=Install /INSTANCENAME=MSSQLSERVER /FEATURES=SQLEngine /UPDATEENABLED=0 /SQLSVCACCOUNT='NT SERVICE\MSSQLSERVER' /SQLSYSADMINACCOUNTS='BUILTIN\ADMINISTRATORS' /TCPENABLED=1 /NPENABLED=0 /IACCEPTSQLSERVERLICENSETERMS
       Set-ItemProperty -path 'HKLM:\Software\Microsoft\Microsoft SQL Server\MSSQL15.MSSQLSERVER\MSSQLSERVER\' -Name LoginMode -Value 2 
       Restart-Service MSSQLSERVER
       sqlcmd -S localhost -q "ALTER LOGIN [sa] WITH PASSWORD=N'$SaPassword'"


### PR DESCRIPTION
This fixes an edge case where:

* New-DbaAvailabilityGroup is used to create an AG on the runner
* The commands are being run in non-interactive PowerShell

When the service account being used is "NT AUTHORITY\SYSTEM" it is returned to the functions as "LocalSystem" which is treated as a SQL Login not an AD login, so a prompt results to ask for a password for the new login during AG permissioning. 

By using this login instead, it should avoid this issue. I have a working example of this where I update the service account after install and am able to create an AG:

https://github.com/lowlydba/lowlydba.sqlserver/blob/b5ef43f6cf736b556ae736af01c70750e8e27de2/.github/workflows/ansible-test-windows.yml#L111-L114

Fixes #9 and then some