### PR TITLE
Add version options

### DIFF
--- a/.github/workflows/simple.yml
+++ b/.github/workflows/simple.yml
@@ -2,12 +2,13 @@ on: [push]
 
 jobs:
   test-everywhere:
-    name: Test Action on all platforms
+    name: Test Action on all platforms and versions
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
+        version: ["2017", "2019"]
 
     steps:
       - uses: actions/checkout@v2
@@ -16,6 +17,7 @@ jobs:
         uses: ./
         with:
           install: sqlengine, sqlclient, sqlpackage, localdb
+          version: ${{ matrix.version }}
 
       - name: Run sqlcmd
         run: sqlcmd -S localhost -U sa -P dbatools.I0 -d tempdb -Q "SELECT @@version;"

--- a/.github/workflows/single.yml
+++ b/.github/workflows/single.yml
@@ -2,7 +2,7 @@ on: [push]
 
 jobs:
   test-everywhere:
-    name: Test Action on all platforms
+    name: Test Action on latest Ubuntu
     runs-on: ubuntu-latest
 
     steps:
@@ -20,4 +20,3 @@ jobs:
         shell: pwsh
         run: |
           ./Test-Collation -ExpectedCollation SQL_Latin1_General_CP1_CI_AS -UserName sa -Password dbatools.I0
-

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,10 @@ inputs:
     description: "Change the collation associated with the SQL Server instance"
     required: false
     default: "SQL_Latin1_General_CP1_CI_AS"
+  version:
+    description: "The version of SQL Server to install in year format"
+    required: false
+    default: "2019"
 runs:
   using: "composite"
   steps:
@@ -37,6 +41,7 @@ runs:
             SaPassword      = "${{ inputs.sa-password }}"
             ShowLog         = $${{ inputs.show-log }}
             Collation       = "${{ inputs.Collation }}"
+            Version         = "${{ inputs.Version }}"
         }
 
         ${{ github.action_path }}/main.ps1 @params


### PR DESCRIPTION
Add pieces to allow for different versions of SQL Server to install, along with any shiny new install flags that may come with them.

I'm having trouble getting the raw link behind "https://go.microsoft.com/fwlink/?linkid=840945" - not sure how important it is to get that figured out.