### PR TITLE
Enable sa account for LocalDB

### DIFF
--- a/main.ps1
+++ b/main.ps1
@@ -170,7 +170,7 @@ if ("localdb" -in $Install) {
         Write-Host "Checking"
         sqlcmd -S "(localdb)\MSSQLLocalDB" -Q "SELECT @@VERSION;"
         sqlcmd -S "(localdb)\MSSQLLocalDB" -Q "ALTER LOGIN [sa] WITH PASSWORD=N'$SaPassword'"
-        sqlcmd -S localhost -q "ALTER LOGIN [sa] ENABLE"
+        sqlcmd -S "(localdb)\MSSQLLocalDB" -Q "ALTER LOGIN [sa] ENABLE"
 
         Write-Host "SqlLocalDB $Version installed and accessible at (localdb)\MSSQLLocalDB"
     } else {

--- a/main.ps1
+++ b/main.ps1
@@ -170,6 +170,7 @@ if ("localdb" -in $Install) {
         Write-Host "Checking"
         sqlcmd -S "(localdb)\MSSQLLocalDB" -Q "SELECT @@VERSION;"
         sqlcmd -S "(localdb)\MSSQLLocalDB" -Q "ALTER LOGIN [sa] WITH PASSWORD=N'$SaPassword'"
+        sqlcmd -S localhost -q "ALTER LOGIN [sa] ENABLE"
 
         Write-Host "SqlLocalDB $Version installed and accessible at (localdb)\MSSQLLocalDB"
     } else {


### PR DESCRIPTION
This fixes the following error received when connecting to LocalDB: `Login failed for user 'sa'. Reason: The account is disabled.`
