### PR TITLE
Speed up and Fix Docker on Mac using Colima

### DIFF
--- a/.github/workflows/advanced.yml
+++ b/.github/workflows/advanced.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   test-everywhere:
-    name: Test Action on all platforms
+    name: Test All Platforms
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -14,13 +14,31 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Run the action
+      - name: Install sqlengine
         uses: ./
         with:
-          install: sqlengine, sqlclient, sqlpackage, localdb
+          install: sqlengine
           sa-password: c0MplicatedP@ssword
           show-log: true
           collation: Latin1_General_BIN
+
+      - name: Install sqlclient
+        uses: ./
+        with:
+          install: sqlclient
+          show-log: true
+
+      - name: Install sqlpackage
+        uses: ./
+        with:
+          install: sqlpackage
+          show-log: true
+
+      - name: Install localdb
+        uses: ./
+        with:
+          install: localdb
+          show-log: true
 
       - name: Run sqlcmd
         run: sqlcmd -S localhost -U sa -P c0MplicatedP@ssword -d tempdb -Q "SELECT @@version;"

--- a/.github/workflows/advanced.yml
+++ b/.github/workflows/advanced.yml
@@ -12,7 +12,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Run the action
         uses: ./

--- a/.github/workflows/simple.yml
+++ b/.github/workflows/simple.yml
@@ -11,7 +11,7 @@ jobs:
         version: ["2017", "2019", "2022"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Run the action
         uses: ./

--- a/.github/workflows/simple.yml
+++ b/.github/workflows/simple.yml
@@ -2,7 +2,7 @@ on: [push]
 
 jobs:
   test-everywhere:
-    name: Test Action on all platforms and versions
+    name: Test all platforms/versions
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/single.yml
+++ b/.github/workflows/single.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Run the action
         uses: potatoqualitee/mssqlsuite@v1.1

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Run the action
         uses: potatoqualitee/mssqlsuite@v1.5.1
@@ -86,7 +86,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Run the action
         uses: potatoqualitee/mssqlsuite@v1.5.1

--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ None
 | SqlLocalDB | localdb | Windows | Accessible at `(localdb)\MSSQLLocalDB` | ~30s |
 | Client Tools | sqlclient | Windows | Already included in runner, including sqlcmd, bcp, and odbc drivers | N/A |
 | sqlpackage | sqlpackage | Windows | Installed using chocolatey | ~1.5m |
-| SQL Engine | sqlengine | macOS | Docker container with SQL Server 2019 running on VirtualBox, accessible at `localhost`. Docker [not supported on macOS](https://github.community/t/why-is-docker-not-installed-on-macos/17017) in GitHub Actions. | ~5m |
+| SQL Engine | sqlengine | macOS | Docker container with SQL Server 2019 accessible at `localhost`. | ~3m |
 | SqlLocalDB | localdb | macOS | Not supported | N/A |
-| Client Tools | sqlclient | macOS | Includes sqlcmd, bcp, and odbc drivers | ~2m |
-| sqlpackage | sqlpackage | macOS | Installed from web | ~25s |
+| Client Tools | sqlclient | macOS | Includes sqlcmd, bcp, and odbc drivers | ~30s |
+| sqlpackage | sqlpackage | macOS | Installed from web | ~5s |
 
 ### Example workflows
 

--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,6 @@ runs:
         ACCEPT_EULA: "Y"
         SA_PASSWORD: ${{ inputs.sa-password }}
         MSSQL_AGENT_ENABLED: "true"
-        HOMEBREW_NO_ENV_FILTERING: "1"
       run: |
         Write-Output "Getting variables for suite"
 

--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,7 @@ runs:
       shell: pwsh
       env:
         ACCEPT_EULA: "Y"
+        HOMEBREW_ACCEPT_EULA: "Y"
         SA_PASSWORD: ${{ inputs.sa-password }}
         MSSQL_AGENT_ENABLED: "true"
       run: |

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,7 @@ runs:
       env:
         ACCEPT_EULA: "Y"
         HOMEBREW_ACCEPT_EULA: "Y"
+        HOMEBREW_NO_INSTALL_CLEANUP: "Y"
         SA_PASSWORD: ${{ inputs.sa-password }}
         MSSQL_AGENT_ENABLED: "true"
       run: |

--- a/main.ps1
+++ b/main.ps1
@@ -89,7 +89,7 @@ if ("sqlclient" -in $Install) {
         Write-Output "Installing sqlclient tools"
         brew tap microsoft/mssql-release https://github.com/Microsoft/homebrew-mssql-release
         #$null = brew update
-        $log = HOMEBREW_ACCEPT_EULA=y brew install microsoft/mssql-release/msodbcsql17 microsoft/mssql-release/mssql-tools
+        $log = brew install microsoft/mssql-release/msodbcsql17 microsoft/mssql-release/mssql-tools
 
         if ($ShowLog) {
             $log

--- a/main.ps1
+++ b/main.ps1
@@ -89,7 +89,7 @@ if ("sqlclient" -in $Install) {
         Write-Output "Installing sqlclient tools"
         brew tap microsoft/mssql-release https://github.com/Microsoft/homebrew-mssql-release
         #$null = brew update
-        $log = brew microsoft/mssql-release/install microsoft/mssql-release/msodbcsql17 microsoft/mssql-release/mssql-tools
+        $log = brew install microsoft/mssql-release/msodbcsql17 microsoft/mssql-release/mssql-tools
 
         if ($ShowLog) {
             $log

--- a/main.ps1
+++ b/main.ps1
@@ -89,7 +89,7 @@ if ("sqlclient" -in $Install) {
         Write-Output "Installing sqlclient tools"
         brew tap microsoft/mssql-release https://github.com/Microsoft/homebrew-mssql-release
         #$null = brew update
-        $log = brew install microsoft/mssql-release/msodbcsql17 microsoft/mssql-release/mssql-tools
+        $log = ACCEPT_EULA=y brew install microsoft/mssql-release/msodbcsql17 microsoft/mssql-release/mssql-tools
 
         if ($ShowLog) {
             $log

--- a/main.ps1
+++ b/main.ps1
@@ -89,7 +89,7 @@ if ("sqlclient" -in $Install) {
         Write-Output "Installing sqlclient tools"
         brew tap microsoft/mssql-release https://github.com/Microsoft/homebrew-mssql-release
         #$null = brew update
-        $log = ACCEPT_EULA=y brew install microsoft/mssql-release/msodbcsql17 microsoft/mssql-release/mssql-tools
+        $log = ACCEPT_EULA=y HOMEBREW_ACCEPT_EULA=y brew install microsoft/mssql-release/msodbcsql17 microsoft/mssql-release/mssql-tools
 
         if ($ShowLog) {
             $log

--- a/main.ps1
+++ b/main.ps1
@@ -13,6 +13,7 @@ if ("sqlengine" -in $Install) {
     if ($ismacos) {
         Write-Output "mac detected, installing docker then downloading a docker container"
         #$Env:HOMEBREW_NO_AUTO_UPDATE = 1
+        Write-Output "brew install kubectl docker coreutils lima"
         brew install kubectl docker coreutils lima
         colima start --runtime docker
         Start-Sleep 5

--- a/main.ps1
+++ b/main.ps1
@@ -89,7 +89,7 @@ if ("sqlclient" -in $Install) {
         Write-Output "Installing sqlclient tools"
         brew tap microsoft/mssql-release https://github.com/Microsoft/homebrew-mssql-release
         #$null = brew update
-        $log = ACCEPT_EULA=y HOMEBREW_ACCEPT_EULA=y brew install microsoft/mssql-release/msodbcsql17 microsoft/mssql-release/mssql-tools
+        $log = HOMEBREW_ACCEPT_EULA=y brew install microsoft/mssql-release/msodbcsql17 microsoft/mssql-release/mssql-tools
 
         if ($ShowLog) {
             $log

--- a/main.ps1
+++ b/main.ps1
@@ -12,9 +12,8 @@ if ("sqlengine" -in $Install) {
     Write-Output "Installing SQL Engine"
     if ($ismacos) {
         Write-Output "mac detected, installing docker then downloading a docker container"
-        #$Env:HOMEBREW_NO_AUTO_UPDATE = 1
-        Write-Output "brew install kubectl docker coreutils lima"
-        brew install kubectl docker coreutils lima
+        $Env:HOMEBREW_NO_AUTO_UPDATE = 1
+        brew install docker
         colima start --runtime docker
         Start-Sleep 5
         docker run -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=$SaPassword" -e "MSSQL_COLLATION=$Collation" --name sql -p 1433:1433 --memory="2g" -d "mcr.microsoft.com/mssql/server:$Version-latest"

--- a/main.ps1
+++ b/main.ps1
@@ -13,36 +13,8 @@ if ("sqlengine" -in $Install) {
     if ($ismacos) {
         Write-Output "mac detected, installing docker then downloading a docker container"
         $Env:HOMEBREW_NO_AUTO_UPDATE = 1
-        brew install --cask docker
-        sudo /Applications/Docker.app/Contents/MacOS/Docker --unattended --install-privileged-components
-        open -a /Applications/Docker.app --args --unattended --accept-license
-        Start-Sleep 30
-        $tries = 0
-        Write-Output "We are waiting for Docker to be up and running. It can take over 2 minutes..."
-        do {
-            try {
-                $tries++
-                $sock = Get-ChildItem $home/Library/Containers/com.docker.docker/Data/docker.raw.sock -ErrorAction Stop
-            } catch {
-                Write-Output "Waiting..."
-                Start-Sleep 5
-            }
-        }
-        until ($sock.BaseName -or $tries -gt 55)
-
-        if ($tries -gt 55) {
-            Write-Output "
-
-
-
-         Moving on without waiting for docker to start
-
-
-
-
-         "
-        }
-
+        brew install docker
+        colima start
         docker run -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=$SaPassword" -e "MSSQL_COLLATION=$Collation" --name sql -p 1433:1433 --memory="2g" -d "mcr.microsoft.com/mssql/server:$Version-latest"
         Write-Output "Docker finished running"
         Start-Sleep 5

--- a/main.ps1
+++ b/main.ps1
@@ -15,7 +15,6 @@ if ("sqlengine" -in $Install) {
         $Env:HOMEBREW_NO_AUTO_UPDATE = 1
         brew install docker
         colima start --runtime docker
-        Start-Sleep 5
         docker run -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=$SaPassword" -e "MSSQL_COLLATION=$Collation" --name sql -p 1433:1433 --memory="2g" -d "mcr.microsoft.com/mssql/server:$Version-latest"
         Write-Output "Docker finished running"
         Start-Sleep 5

--- a/main.ps1
+++ b/main.ps1
@@ -88,8 +88,8 @@ if ("sqlclient" -in $Install) {
     if ($ismacos) {
         Write-Output "Installing sqlclient tools"
         brew tap microsoft/mssql-release https://github.com/Microsoft/homebrew-mssql-release
-        $null = brew update
-        $log = brew install msodbcsql17 mssql-tools
+        #$null = brew update
+        $log = brew microsoft/mssql-release/install microsoft/mssql-release/msodbcsql17 microsoft/mssql-release/mssql-tools
 
         if ($ShowLog) {
             $log

--- a/main.ps1
+++ b/main.ps1
@@ -13,8 +13,8 @@ if ("sqlengine" -in $Install) {
     if ($ismacos) {
         Write-Output "mac detected, installing docker then downloading a docker container"
         #$Env:HOMEBREW_NO_AUTO_UPDATE = 1
-        brew install docker
-        colima start
+        brew install kubectl docker coreutils lima
+        colima start --runtime docker
         Start-Sleep 5
         docker run -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=$SaPassword" -e "MSSQL_COLLATION=$Collation" --name sql -p 1433:1433 --memory="2g" -d "mcr.microsoft.com/mssql/server:$Version-latest"
         Write-Output "Docker finished running"

--- a/main.ps1
+++ b/main.ps1
@@ -12,9 +12,10 @@ if ("sqlengine" -in $Install) {
     Write-Output "Installing SQL Engine"
     if ($ismacos) {
         Write-Output "mac detected, installing docker then downloading a docker container"
-        $Env:HOMEBREW_NO_AUTO_UPDATE = 1
+        #$Env:HOMEBREW_NO_AUTO_UPDATE = 1
         brew install docker
         colima start
+        Start-Sleep 5
         docker run -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=$SaPassword" -e "MSSQL_COLLATION=$Collation" --name sql -p 1433:1433 --memory="2g" -d "mcr.microsoft.com/mssql/server:$Version-latest"
         Write-Output "Docker finished running"
         Start-Sleep 5

--- a/main.ps1
+++ b/main.ps1
@@ -103,7 +103,7 @@ if ("sqlpackage" -in $Install) {
     Write-Output "installing sqlpackage"
 
     if ($ismacos) {
-        curl "https://https://aka.ms/sqlpackage-macos" -4 -sL -o '/tmp/sqlpackage.zip'
+        curl "https://aka.ms/sqlpackage-macos" -4 -sL -o '/tmp/sqlpackage.zip'
         $log = unzip /tmp/sqlpackage.zip -d $HOME/sqlpackage
         chmod +x $HOME/sqlpackage/sqlpackage
         sudo ln -sf $HOME/sqlpackage/sqlpackage /usr/local/bin


### PR DESCRIPTION
GitHub [recently added](https://github.com/actions/runner-images/pull/6285) Colima to their images.

Colima provides container runtimes on macOS (and Linux) with minimal setup, which means you can run docker without having to install Docker for macOS and run into licensing issues (https://github.com/actions/runner-images/issues/2150).

This speeds up the macOS implementation by a huge amount because VirtualBox is no longer required.

I also tightened up the homebrew installer so that it doesn't have to update. I did this by being explicit about which repository I wanted to grab the sqltools from.
