### PR TITLE
fix RC link for 2022 binaries

### DIFF
--- a/main.ps1
+++ b/main.ps1
@@ -61,8 +61,8 @@ if ("sqlengine" -in $Install) {
                 $versionMajor = 15
             }
             "2022" {
-                $exeUri = "https://download.microsoft.com/download/4/0/2/4027643f-d845-4250-ae93-e66854ee1de6/SQLServer2022-x64-ENU.exe"
-                $boxUri = "https://download.microsoft.com/download/4/0/2/4027643f-d845-4250-ae93-e66854ee1de6/SQLServer2022-x64-ENU.box"
+                $exeUri = "https://download.microsoft.com/download/3/8/d/38de7036-2433-4207-8eae-06e247e17b25/SQLServer2022-DEV-x64-ENU.exe"
+                $boxUri = "https://download.microsoft.com/download/3/8/d/38de7036-2433-4207-8eae-06e247e17b25/SQLServer2022-DEV-x64-ENU.box"
                 $installOptions = "/USESQLRECOMMENDEDMEMORYLIMITS"
                 $versionMajor = 16
             }


### PR DESCRIPTION
Oops! They did change the links up after all, sorry about that! 

It does look like the `.box` isn't downloading though (launch day saturation?) so it might be worth keeping the current CTP links in place until the files are actually downloadable - right now requests just hang.