### PR TITLE
Adding missing sqlcmd for ubuntu; fixing macOS; removing 2017; defaulting to 2022

### DIFF
--- a/.github/workflows/advanced.yml
+++ b/.github/workflows/advanced.yml
@@ -41,7 +41,7 @@ jobs:
           show-log: true
 
       - name: Run sqlcmd
-        run: sqlcmd -S localhost -U sa -P c0MplicatedP@ssword -d tempdb -Q "SELECT @@version;"
+        run: sqlcmd -S localhost -U sa -P c0MplicatedP@ssword -d tempdb -Q "SELECT @@version;" -C
 
       - name: Check collation
         shell: pwsh

--- a/.github/workflows/simple.yml
+++ b/.github/workflows/simple.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        version: ["2017", "2019", "2022"]
+        version: ["2019", "2022"]
 
     steps:
       - uses: actions/checkout@v3
@@ -20,7 +20,7 @@ jobs:
           version: ${{ matrix.version }}
 
       - name: Run sqlcmd
-        run: sqlcmd -S localhost -U sa -P dbatools.I0 -d tempdb -Q "SELECT @@version;"
+        run: sqlcmd -S localhost -U sa -P dbatools.I0 -d tempdb -Q "SELECT @@version;" -C
 
       - name: Check collation
         shell: pwsh

--- a/.github/workflows/single.yml
+++ b/.github/workflows/single.yml
@@ -14,7 +14,7 @@ jobs:
           install: sqlengine, sqlclient, sqlpackage, localdb
 
       - name: Run sqlclient
-        run: sqlcmd -S localhost -U sa -P dbatools.I0 -d tempdb -Q "SELECT @@version;"
+        run: sqlcmd -S localhost -U sa -P dbatools.I0 -d tempdb -Q "SELECT @@version;" -C
 
       - name: Check collation
         shell: pwsh

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Create a workflow `.yml` file in your repositories `.github/workflows` directory
 * `install` - The apps to install. Options include: `sqlengine`, `sqlclient`, `sqlpackage`, and `localdb`
 * `sa-password` - The sa password for the SQL instance. The default is `dbatools.I0`
 * `collation` - Change the collation associated with the SQL Server instance
-* `version` - The version of SQL Server to install in year format. Options are 2017 and 2019, defaults to 2019
+* `version` - The version of SQL Server to install in year format. Options are 2019 and 2022 (defaults to 2022)
 * `show-log` - Show logs, including docker logs, for troubleshooting
 
 ### Outputs
@@ -34,22 +34,22 @@ None
 
 | Application | Keyword | OS | Details | Time |
 | -------------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ | ------------- |
-| SQL Engine | sqlengine | Linux | Docker container with SQL Server 2019, accessible at `localhost` | ~45s |
+| SQL Engine | sqlengine | Linux | Docker container with SQL Server 2022, accessible at `localhost` | ~30s |
 | SqlLocalDB | localdb | Linux | Not supported | N/A |
-| Client Tools | sqlclient | Linux | Already included in runner, including sqlcmd, bcp, and odbc drivers | N/A |
-| sqlpackage | sqlpackage | Linux | Installed from web | ~20s |
-| SQL Engine | sqlengine | Windows | Full install of SQL Server 2019, accessible at `localhost`. Docker took like 15 minutes. Windows and SQL authentication both supported. | ~5m |
+| Client Tools | sqlclient | Linux | Includes sqlcmd, bcp, and odbc drivers | ~15s |
+| sqlpackage | sqlpackage | Linux | Installed from web | ~5s |
+| SQL Engine | sqlengine | Windows | Full install of SQL Server 2022, accessible at `localhost`. Docker took like 15 minutes. Windows and SQL authentication both supported. | ~3m |
 | SqlLocalDB | localdb | Windows | Accessible at `(localdb)\MSSQLLocalDB` | ~30s |
 | Client Tools | sqlclient | Windows | Already included in runner, including sqlcmd, bcp, and odbc drivers | N/A |
-| sqlpackage | sqlpackage | Windows | Installed using chocolatey | ~1.5m |
-| SQL Engine | sqlengine | macOS | Docker container with SQL Server 2019 accessible at `localhost`. | ~3m |
+| sqlpackage | sqlpackage | Windows | Installed using chocolatey | ~20s |
+| SQL Engine | sqlengine | macOS | Docker container with SQL Server 2022 accessible at `localhost`. | ~7m |
 | SqlLocalDB | localdb | macOS | Not supported | N/A |
-| Client Tools | sqlclient | macOS | Includes sqlcmd, bcp, and odbc drivers | ~30s |
+| Client Tools | sqlclient | macOS | Includes sqlcmd, bcp, and odbc drivers | ~20s |
 | sqlpackage | sqlpackage | macOS | Installed from web | ~5s |
 
 ### Example workflows
 
-Create a SQL Server 2019 container and sqlpackage on Linux (the fastest runner, by far)
+Create a SQL Server 2022 container and sqlpackage on Linux (the fastest runner, by far)
 
 ```yaml
 on: [push]
@@ -68,7 +68,7 @@ jobs:
           install: sqlengine, sqlpackage
 
       - name: Run sqlclient
-        run: sqlcmd -S localhost -U sa -P dbatools.I0 -d tempdb -Q "SELECT @@version;"
+        run: sqlcmd -S localhost -U sa -P dbatools.I0 -d tempdb -Q "SELECT @@version;" -C
 ```
 
 Installing everything on all OSes, plus using a different sa password and collation
@@ -92,19 +92,21 @@ jobs:
         uses: potatoqualitee/mssqlsuite@v1.7
         with:
           install: sqlengine, sqlclient, sqlpackage, localdb
-          version: 2017
+          version: 2019
           sa-password: c0MplicatedP@ssword
           show-log: true
           collation: Latin1_General_BIN
 
       - name: Run sqlcmd
-        run: sqlcmd -S localhost -U sa -P c0MplicatedP@ssword -d tempdb -Q "SELECT @@version;"
+        run: sqlcmd -S localhost -U sa -P c0MplicatedP@ssword -d tempdb -Q "SELECT @@version;" -C
 ```
 
 ## Contributing
 Pull requests are welcome!
 
 ## TODO
+* Add LocalDB support for SQL Server 2022.
+* MacOS: Migrate docker from qemu to vz to speed up the process.
 * Wait for GitHub Actions to support more stuff to make the install sleeker.
 * Maybe more tools from [here](https://docs.microsoft.com/en-us/sql/tools/sqlpackage/sqlpackage-download?view=sql-server-ver15).
   * mssql-cli (command-line query tool)

--- a/Test-Collation.ps1
+++ b/Test-Collation.ps1
@@ -7,7 +7,7 @@ param(
     [string]$Password
 )
 
-$Collation = sqlcmd -S localhost -d tempdb -U $UserName -P $Password -Q "SET NOCOUNT ON;SELECT SERVERPROPERTY('Collation') AS Collation;" -W -h -1
+$Collation = sqlcmd -S localhost -d tempdb -U $UserName -P $Password -Q "SET NOCOUNT ON;SELECT SERVERPROPERTY('Collation') AS Collation;" -W -h -1 -C
 
 if ($Collation -ne $ExpectedCollation){
     throw "Collation is $Collation.  Expected $ExpectedCollation"

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
   version:
     description: "The version of SQL Server to install in year format"
     required: false
-    default: "2019"
+    default: "2022"
 runs:
   using: "composite"
   steps:
@@ -40,7 +40,7 @@ runs:
         $params = @{
             Install         = ("${{ inputs.install }}" -split ",").Trim()
             SaPassword      = "${{ inputs.sa-password }}"
-            ShowLog         = ${{ inputs.show-log }}
+            ShowLog         = ("${{ inputs.show-log }}" -ieq "true")
             Collation       = "${{ inputs.Collation }}"
             Version         = "${{ inputs.Version }}"
         }

--- a/main.ps1
+++ b/main.ps1
@@ -1,41 +1,40 @@
 param (
     [ValidateSet("sqlclient", "sqlpackage", "sqlengine", "localdb")]
     [string[]]$Install,
-    [string]$SaPassword,
+    [string]$SaPassword = "dbatools.I0",
     [switch]$ShowLog,
     [string]$Collation = "SQL_Latin1_General_CP1_CI_AS",
-    [ValidateSet("2022","2019", "2017")]
-    [string]$Version = "2019"
+    [ValidateSet("2022", "2019")]
+    [string]$Version = "2022"
 )
 
 if ("sqlengine" -in $Install) {
     Write-Output "Installing SQL Engine"
     if ($ismacos) {
-        Write-Output "mac detected, installing docker then downloading a docker container"
+        Write-Output "mac detected, installing colima and docker"
         $Env:HOMEBREW_NO_AUTO_UPDATE = 1
-        brew install docker
-        colima start --runtime docker
-        docker run -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=$SaPassword" -e "MSSQL_COLLATION=$Collation" --name sql -p 1433:1433 --memory="2g" -d "mcr.microsoft.com/mssql/server:$Version-latest"
-        Write-Output "Docker finished running"
-        Start-Sleep 5
-        if ($ShowLog) {
-            docker ps -a
-            docker logs -t sql
-        }
-
-        Write-Output "sql engine installed at localhost"
+        brew install docker colima qemu
+        colima --verbose start -a x86_64 --cpu 4 --memory 4 --runtime docker
     }
 
-    if ($islinux) {
-        Write-Output "linux detected, downloading the docker container"
+    if ($ismacos -or $islinux) {
+        Write-Output "linux/mac detected, downloading the docker container"
+
         docker run -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=$SaPassword" -e "MSSQL_COLLATION=$Collation" --name sql -p 1433:1433 -d "mcr.microsoft.com/mssql/server:$Version-latest"
         Write-Output "Waiting for docker to start"
-        Start-Sleep -Seconds 10
+
+        # MacOS takes longer to start using qemu
+        if ($ismacos) {
+            Start-Sleep -Seconds 90
+        } else {
+            Start-Sleep -Seconds 10
+        }
 
         if ($ShowLog) {
             docker ps -a
             docker logs -t sql
         }
+
         Write-Output "docker container running - sql server accessible at localhost"
     }
 
@@ -48,22 +47,14 @@ if ("sqlengine" -in $Install) {
         Push-Location C:\temp
         $ProgressPreference = "SilentlyContinue"
         switch ($Version) {
-            "2017" {
-                $exeUri = "https://download.microsoft.com/download/E/F/2/EF23C21D-7860-4F05-88CE-39AA114B014B/SQLServer2017-DEV-x64-ENU.exe"
-                $boxUri = "https://download.microsoft.com/download/E/F/2/EF23C21D-7860-4F05-88CE-39AA114B014B/SQLServer2017-DEV-x64-ENU.box"
-                $installOptions = ""
-                $versionMajor = 14
-            }
             "2019" {
                 $exeUri = "https://download.microsoft.com/download/7/c/1/7c14e92e-bdcb-4f89-b7cf-93543e7112d1/SQLServer2019-DEV-x64-ENU.exe"
                 $boxUri = "https://download.microsoft.com/download/7/c/1/7c14e92e-bdcb-4f89-b7cf-93543e7112d1/SQLServer2019-DEV-x64-ENU.box"
-                $installOptions = "/USESQLRECOMMENDEDMEMORYLIMITS"
                 $versionMajor = 15
             }
             "2022" {
                 $exeUri = "https://download.microsoft.com/download/3/8/d/38de7036-2433-4207-8eae-06e247e17b25/SQLServer2022-DEV-x64-ENU.exe"
                 $boxUri = "https://download.microsoft.com/download/3/8/d/38de7036-2433-4207-8eae-06e247e17b25/SQLServer2022-DEV-x64-ENU.box"
-                $installOptions = "/USESQLRECOMMENDEDMEMORYLIMITS"
                 $versionMajor = 16
             }
         }
@@ -71,12 +62,12 @@ if ("sqlengine" -in $Install) {
         Invoke-WebRequest -Uri $boxUri -OutFile sqlsetup.box
         Start-Process -Wait -FilePath ./sqlsetup.exe -ArgumentList /qs, /x:setup
 
-        .\setup\setup.exe /q /ACTION=Install /INSTANCENAME=MSSQLSERVER /FEATURES=SQLEngine /UPDATEENABLED=0 /SQLSVCACCOUNT='NT SERVICE\MSSQLSERVER' /SQLSYSADMINACCOUNTS='BUILTIN\ADMINISTRATORS' /TCPENABLED=1 /NPENABLED=0 /IACCEPTSQLSERVERLICENSETERMS /SQLCOLLATION=$Collation $installOptions
+        .\setup\setup.exe /q /ACTION=Install /INSTANCENAME=MSSQLSERVER /FEATURES=SQLEngine /UPDATEENABLED=0 /SQLSVCACCOUNT='NT SERVICE\MSSQLSERVER' /SQLSYSADMINACCOUNTS='BUILTIN\ADMINISTRATORS' /TCPENABLED=1 /NPENABLED=0 /IACCEPTSQLSERVERLICENSETERMS /SQLCOLLATION=$Collation /USESQLRECOMMENDEDMEMORYLIMITS
 
         Set-ItemProperty -path "HKLM:\Software\Microsoft\Microsoft SQL Server\MSSQL$versionMajor.MSSQLSERVER\MSSQLSERVER\" -Name LoginMode -Value 2
         Restart-Service MSSQLSERVER
-        sqlcmd -S localhost -q "ALTER LOGIN [sa] WITH PASSWORD=N'$SaPassword'"
-        sqlcmd -S localhost -q "ALTER LOGIN [sa] ENABLE"
+        sqlcmd -S localhost -q "ALTER LOGIN [sa] WITH PASSWORD=N'$SaPassword'" -C
+        sqlcmd -S localhost -q "ALTER LOGIN [sa] ENABLE" -C
         Pop-Location
 
         Write-Output "sql server $Version installed at localhost and accessible with both windows and sql auth"
@@ -84,15 +75,27 @@ if ("sqlengine" -in $Install) {
 }
 
 if ("sqlclient" -in $Install) {
+    Write-Output "Installing sqlclient tools"
+    $log = ""
+
     if ($ismacos) {
-        Write-Output "Installing sqlclient tools"
         brew tap microsoft/mssql-release https://github.com/Microsoft/homebrew-mssql-release
         #$null = brew update
-        $log = brew install microsoft/mssql-release/msodbcsql17 microsoft/mssql-release/mssql-tools
+        $log = brew install microsoft/mssql-release/msodbcsql18 microsoft/mssql-release/mssql-tools18
 
-        if ($ShowLog) {
-            $log
-        }
+        echo "/opt/homebrew/bin" >> $env:GITHUB_PATH
+    }
+    
+    if ($islinux) {
+        bash -c "curl https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list"
+        $null = bash -c "sudo apt-get update"
+        $log = bash -c "sudo ACCEPT_EULA=Y apt-get install -y msodbcsql18 mssql-tools18"
+
+        echo "/opt/mssql-tools18/bin" >> $env:GITHUB_PATH
+    }
+
+    if ($ShowLog) {
+        $log
     }
 
     Write-Output "sqlclient tools are installed"
@@ -142,20 +145,20 @@ if ("localdb" -in $Install) {
             Write-Host "Downloading SqlLocalDB"
             $ProgressPreference = "SilentlyContinue"
             switch ($Version) {
-                "2017" { $uriMSI = "https://download.microsoft.com/download/E/F/2/EF23C21D-7860-4F05-88CE-39AA114B014B/SqlLocalDB.msi" }
                 "2019" { $uriMSI = "https://download.microsoft.com/download/7/c/1/7c14e92e-bdcb-4f89-b7cf-93543e7112d1/SqlLocalDB.msi" }
+                "2022" { $uriMSI = "TBD" }
             }
             Invoke-WebRequest -Uri $uriMSI -OutFile SqlLocalDB.msi
             Write-Host "Installing"
             Start-Process -FilePath "SqlLocalDB.msi" -Wait -ArgumentList "/qn", "/norestart", "/l*v SqlLocalDBInstall.log", "IACCEPTSQLLOCALDBLICENSETERMS=YES";
             Write-Host "Checking"
-            sqlcmd -S "(localdb)\MSSQLLocalDB" -Q "SELECT @@VERSION;"
-            sqlcmd -S "(localdb)\MSSQLLocalDB" -Q "ALTER LOGIN [sa] WITH PASSWORD=N'$SaPassword'"
-            sqlcmd -S "(localdb)\MSSQLLocalDB" -Q "ALTER LOGIN [sa] ENABLE"
+            sqlcmd -S "(localdb)\MSSQLLocalDB" -Q "SELECT @@VERSION;" -C
+            sqlcmd -S "(localdb)\MSSQLLocalDB" -Q "ALTER LOGIN [sa] WITH PASSWORD=N'$SaPassword'" -C
+            sqlcmd -S "(localdb)\MSSQLLocalDB" -Q "ALTER LOGIN [sa] ENABLE" -C
 
             Write-Host "SqlLocalDB $Version installed and accessible at (localdb)\MSSQLLocalDB"
         }
     } else {
-        Write-Output "localdb cannot be isntalled on mac or linux"
+        Write-Output "localdb cannot be installed on mac or linux"
     }
 }


### PR DESCRIPTION
- Adding missing sqlcmd to ubuntu 24.04 runners (Closes Issue #28)
- Adding colima and qemu to allow MacOS builds to pass again
- Fixing show-log parameter handling
- Allowing self-signed certificates when using sqlcmd
- Default to SQL Server 2022
- Removing support for SQL Server 2017 (out of support and broken)