### PR TITLE
[Bug] Fixing path for Full-Text in Linux/MacOS

### DIFF
--- a/main.ps1
+++ b/main.ps1
@@ -21,7 +21,7 @@ if ("sqlengine" -in $Install) {
         Write-Output "linux/mac detected, downloading the docker container"
 
         if ("fulltext" -in $Install) {
-            docker build -f Dockerfile-$Version -t mssql-fulltext .
+            docker build -f $PSScriptRoot/Dockerfile-$Version -t mssql-fulltext .
             $img = "mssql-fulltext"
         } else {
             $img = "mcr.microsoft.com/mssql/server:$Version-latest"


### PR DESCRIPTION
Fixing the path of the Dockerfile when using the `fulltext` option in Linux/MacOS