### PR TITLE
Add custom admin username support

### DIFF
--- a/.github/workflows/single.yml
+++ b/.github/workflows/single.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run the action
-        uses: potatoqualitee/mssqlsuite@v1.9
+        uses: potatoqualitee/mssqlsuite@v1.10
         with:
           install: sqlengine, sqlclient, sqlpackage, localdb
 
@@ -20,3 +20,30 @@ jobs:
         shell: pwsh
         run: |
           ./Test-Collation -ExpectedCollation SQL_Latin1_General_CP1_CI_AS -UserName sa -Password dbatools.I0
+
+  test-custom-admin:
+    name: Test Custom Admin Username
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run the action with custom admin
+        uses: potatoqualitee/mssqlsuite@v1.10
+        with:
+          install: sqlengine, sqlclient
+          admin-username: dbadmin
+          sa-password: TestP@ssword123
+
+      - name: Test connection with custom admin user
+        run: sqlcmd -S localhost -U dbadmin -P TestP@ssword123 -d tempdb -Q "SELECT @@version;" -C
+
+      - name: Check collation with custom admin
+        shell: pwsh
+        run: |
+          ./Test-Collation -ExpectedCollation SQL_Latin1_General_CP1_CI_AS -UserName dbadmin -Password TestP@ssword123
+
+      - name: Test custom admin functionality
+        shell: pwsh
+        run: |
+          ./Test-CustomAdmin -AdminUsername dbadmin -Password TestP@ssword123

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Just copy the code below and modify the line **`install: sqlengine, sqlclient, s
 
 ```yaml
     - name: Install a SQL Server suite of tools
-      uses: potatoqualitee/mssqlsuite@v1.9
+      uses: potatoqualitee/mssqlsuite@v1.10
       with:
         install: sqlengine, sqlclient, sqlpackage, localdb, fulltext
 ```
@@ -22,6 +22,7 @@ Create a workflow `.yml` file in your repositories `.github/workflows` directory
 
 * `install` - The apps to install. Options include: `sqlengine`, `sqlclient`, `sqlpackage`, `localdb`, and `fulltext`
 * `sa-password` - The sa password for the SQL instance. The default is `dbatools.I0`
+* `admin-username` - The admin username for the SQL instance. The default is `sa`. When specified, the built-in `sa` user will be renamed to this username
 * `collation` - Change the collation associated with the SQL Server instance
 * `version` - The version of SQL Server to install in year format. Options are 2019 and 2022 (defaults to 2022)
 * `show-log` - Show logs, including docker logs, for troubleshooting
@@ -66,7 +67,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run the action
-        uses: potatoqualitee/mssqlsuite@v1.9
+        uses: potatoqualitee/mssqlsuite@v1.10
         with:
           install: sqlengine, sqlpackage
 
@@ -92,7 +93,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run the action
-        uses: potatoqualitee/mssqlsuite@v1.9
+        uses: potatoqualitee/mssqlsuite@v1.10
         with:
           install: sqlengine, sqlclient, sqlpackage, localdb, fulltext
           version: 2019
@@ -102,6 +103,30 @@ jobs:
 
       - name: Run sqlcmd
         run: sqlcmd -S localhost -U sa -P c0MplicatedP@ssword -d tempdb -Q "SELECT @@version;" -C
+```
+
+Using a custom admin username instead of the default 'sa'
+
+```yaml
+on: [push]
+
+jobs:
+  test-custom-admin:
+    name: Test with custom admin user
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run the action with custom admin
+        uses: potatoqualitee/mssqlsuite@v1.10
+        with:
+          install: sqlengine, sqlclient
+          admin-username: dbadmin
+          sa-password: MySecureP@ssword123
+
+      - name: Test connection with custom admin user
+        run: sqlcmd -S localhost -U dbadmin -P MySecureP@ssword123 -d tempdb -Q "SELECT @@version;" -C
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # mssqlsuite
 This GitHub Action automatically installs a SQL Server suite of tools including sqlcmd, bcp, sqlpackage, the sql engine, localdb and more for Windows, macOS and Linux.
 
+> **Note:** `sqlcmd` is always installed by default because this action needs it to execute some SQL.
+
 ## Documentation
 
 Just copy the code below and modify the line **`install: sqlengine, sqlclient, sqlpackage, localdb, fulltext`** with the options you need.
@@ -47,7 +49,7 @@ None
 | Full-Text Search | fulltext | Windows | Enabled during SQL Engine install | ~1m |
 | SQL Engine | sqlengine | macOS | Docker container with SQL Server 2022 accessible at `localhost`. | ~7m |
 | SqlLocalDB | localdb | macOS | Not supported | N/A |
-| Client Tools | sqlclient | macOS | Includes sqlcmd, bcp, and odbc drivers | ~20s |
+| Client Tools | sqlclient | macOS | Includes bcp and odbc drivers | ~20s |
 | sqlpackage | sqlpackage | macOS | Installed from web | ~5s |
 | Full-Text Search | fulltext | macOS | Installed using apt-get | ~5m |
 

--- a/Test-CustomAdmin.ps1
+++ b/Test-CustomAdmin.ps1
@@ -1,0 +1,15 @@
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$AdminUsername,
+    [Parameter(Mandatory=$true)]
+    [string]$Password
+)
+
+# Attempt to connect and check if the user is a sysadmin
+$IsSysadmin = sqlcmd -S localhost -d master -U $AdminUsername -P $Password -Q "SET NOCOUNT ON;SELECT IS_SRVROLEMEMBER('sysadmin') AS IsSysadmin;" -W -h -1 -C
+
+if ($IsSysadmin -ne "1") {
+    throw "User $AdminUsername is NOT a sysadmin or cannot connect."
+} else {
+    "User $AdminUsername is a sysadmin."
+}

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,10 @@ inputs:
     description: "The sa password for the SQL instance"
     required: false
     default: "dbatools.I0"
+  admin-username:
+    description: "The admin username for the SQL instance. When specified, the built-in sa user will be renamed to this username"
+    required: false
+    default: "sa"
   show-log:
     description: "Show the log file for the docker container"
     required: false
@@ -40,6 +44,7 @@ runs:
         $params = @{
             Install         = ("${{ inputs.install }}" -split ",").Trim()
             SaPassword      = "${{ inputs.sa-password }}"
+            AdminUsername   = "${{ inputs.admin-username }}"
             ShowLog         = ("${{ inputs.show-log }}" -ieq "true")
             Collation       = "${{ inputs.Collation }}"
             Version         = "${{ inputs.Version }}"

--- a/main.ps1
+++ b/main.ps1
@@ -52,6 +52,21 @@ if ("sqlengine" -in $Install) {
         # Rename sa user if custom admin username is specified
         if ($AdminUsername -ne "sa") {
             Write-Output "Renaming sa user to: $AdminUsername"
+
+            # Ensure sqlcmd is available for sa renaming
+            if ($islinux) {
+                Write-Output "Installing sqlcmd for sa renaming"
+                bash -c "curl -sSL https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -"
+                bash -c "curl https://packages.microsoft.com/config/ubuntu/\$(lsb_release -rs)/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list"
+                bash -c "sudo apt-get update"
+                bash -c "sudo ACCEPT_EULA=Y apt-get install -y sqlcmd"
+            }
+
+            if ($ismacos) {
+                Write-Output "Installing sqlcmd for sa renaming"
+                brew install sqlcmd
+            }
+
             $renameSql = "ALTER LOGIN [sa] WITH NAME = [$AdminUsername];"
             # Use sqlcmd from host to connect to the Docker container
             sqlcmd -S localhost -U sa -P "$SaPassword" -Q "$renameSql" -C
@@ -138,6 +153,13 @@ if ("sqlengine" -in $Install) {
         # Rename sa user if custom admin username is specified
         if ($AdminUsername -ne "sa") {
             Write-Output "Renaming sa user to: $AdminUsername"
+
+            # Ensure sqlcmd is available for sa renaming (Windows should have it, but install if needed)
+            if (-not (Get-Command sqlcmd -ErrorAction SilentlyContinue)) {
+                Write-Output "Installing sqlcmd for sa renaming"
+                choco install sqlcmd -y --no-progress
+            }
+
             $renameSql = "ALTER LOGIN [sa] WITH NAME = [$AdminUsername];"
             sqlcmd -S localhost -q "$renameSql" -C
             Write-Output "sa user renamed to '$AdminUsername' successfully"
@@ -156,7 +178,7 @@ if ("sqlclient" -in $Install) {
     if ($ismacos) {
         brew tap microsoft/mssql-release https://github.com/Microsoft/homebrew-mssql-release
         #$null = brew update
-        $log = brew install microsoft/mssql-release/msodbcsql18 microsoft/mssql-release/mssql-tools18
+        $log = brew install microsoft/mssql-release/msodbcsql18 microsoft/mssql-release/mssql-tools18 sqlcmd
 
         echo "/opt/homebrew/bin" >> $env:GITHUB_PATH
     }
@@ -171,7 +193,7 @@ if ("sqlclient" -in $Install) {
         # Install prerequisites and SQL tools
         $null = bash -c "sudo apt-get update"
         $log += bash -c "sudo apt-get install -y apt-transport-https"
-        $log += bash -c "sudo ACCEPT_EULA=Y apt-get install -y msodbcsql18 mssql-tools18 unixodbc-dev"
+        $log += bash -c "sudo ACCEPT_EULA=Y apt-get install -y msodbcsql18 mssql-tools18 sqlcmd unixodbc-dev"
 
         # Add to PATH for current session and future sessions
         echo "/opt/mssql-tools18/bin" >> $env:GITHUB_PATH
@@ -212,7 +234,7 @@ if ("sqlpackage" -in $Install) {
     }
 
     if ($iswindows) {
-        $log = choco install sqlpackage
+        $log = choco install sqlpackage sqlcmd -y --no-progress
         if ($ShowLog) {
             $log
             sqlpackage /version
@@ -243,6 +265,13 @@ if ("localdb" -in $Install) {
         # Rename sa user if custom admin username is specified
         if ($AdminUsername -ne "sa") {
             Write-Host "Renaming sa user to: $AdminUsername"
+
+            # Ensure sqlcmd is available for sa renaming (Windows should have it, but install if needed)
+            if (-not (Get-Command sqlcmd -ErrorAction SilentlyContinue)) {
+                Write-Host "Installing sqlcmd for sa renaming"
+                choco install sqlcmd -y --no-progress
+            }
+
             $renameSql = "ALTER LOGIN [sa] WITH NAME = [$AdminUsername];"
             sqlcmd -S "(localdb)\MSSQLLocalDB" -Q "$renameSql" -C
             Write-Host "sa user renamed to '$AdminUsername' successfully"

--- a/main.ps1
+++ b/main.ps1
@@ -14,14 +14,15 @@ Write-Output "Installing sqlcmd before proceeding with other installations"
 
 if ($islinux) {
     Write-Output "Installing sqlcmd on Linux"
-    bash -c "curl -sSL https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -"
-    bash -c "curl https://packages.microsoft.com/config/ubuntu/\$(lsb_release -rs)/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list"
+    bash -c "curl https://packages.microsoft.com/keys/microsoft.asc | sudo tee /etc/apt/trusted.gpg.d/microsoft.asc"
+    bash -c "curl https://packages.microsoft.com/config/ubuntu/22.04/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list"
     bash -c "sudo apt-get update"
-    bash -c "sudo ACCEPT_EULA=Y apt-get install -y sqlcmd"
+    bash -c "sudo apt-get install -y sqlcmd"
 }
 
 if ($ismacos) {
     Write-Output "Installing sqlcmd on macOS"
+    brew update
     brew install sqlcmd
 }
 

--- a/main.ps1
+++ b/main.ps1
@@ -2,6 +2,7 @@ param (
     [ValidateSet("sqlclient", "sqlpackage", "sqlengine", "localdb", "fulltext")]
     [string[]]$Install,
     [string]$SaPassword = "dbatools.I0",
+    [string]$AdminUsername = "sa",
     [switch]$ShowLog,
     [string]$Collation = "SQL_Latin1_General_CP1_CI_AS",
     [ValidateSet("2022", "2019", "2017", "2016")]
@@ -46,6 +47,15 @@ if ("sqlengine" -in $Install) {
         if ($ShowLog) {
             docker ps -a
             docker logs -t sql
+        }
+
+        # Rename sa user if custom admin username is specified
+        if ($AdminUsername -ne "sa") {
+            Write-Output "Renaming sa user to: $AdminUsername"
+            $renameSql = "ALTER LOGIN [sa] WITH NAME = [$AdminUsername];"
+            # Use sqlcmd from host to connect to the Docker container
+            sqlcmd -S localhost -U sa -P "$SaPassword" -Q "$renameSql" -C
+            Write-Output "sa user renamed to '$AdminUsername' successfully"
         }
 
         Write-Output "docker container running - sql server accessible at localhost"
@@ -124,6 +134,15 @@ if ("sqlengine" -in $Install) {
         Restart-Service MSSQLSERVER
         sqlcmd -S localhost -q "ALTER LOGIN [sa] WITH PASSWORD=N'$SaPassword'" -C
         sqlcmd -S localhost -q "ALTER LOGIN [sa] ENABLE" -C
+
+        # Rename sa user if custom admin username is specified
+        if ($AdminUsername -ne "sa") {
+            Write-Output "Renaming sa user to: $AdminUsername"
+            $renameSql = "ALTER LOGIN [sa] WITH NAME = [$AdminUsername];"
+            sqlcmd -S localhost -q "$renameSql" -C
+            Write-Output "sa user renamed to '$AdminUsername' successfully"
+        }
+
         Pop-Location
 
         Write-Output "sql server $Version installed at localhost and accessible with both windows and sql auth"
@@ -220,6 +239,14 @@ if ("localdb" -in $Install) {
         sqlcmd -S "(localdb)\MSSQLLocalDB" -Q "SELECT @@VERSION;" -C
         sqlcmd -S "(localdb)\MSSQLLocalDB" -Q "ALTER LOGIN [sa] WITH PASSWORD=N'$SaPassword'" -C
         sqlcmd -S "(localdb)\MSSQLLocalDB" -Q "ALTER LOGIN [sa] ENABLE" -C
+
+        # Rename sa user if custom admin username is specified
+        if ($AdminUsername -ne "sa") {
+            Write-Host "Renaming sa user to: $AdminUsername"
+            $renameSql = "ALTER LOGIN [sa] WITH NAME = [$AdminUsername];"
+            sqlcmd -S "(localdb)\MSSQLLocalDB" -Q "$renameSql" -C
+            Write-Host "sa user renamed to '$AdminUsername' successfully"
+        }
 
         Write-Host "SqlLocalDB $Version installed and accessible at (localdb)\MSSQLLocalDB"
     } else {

--- a/main.ps1
+++ b/main.ps1
@@ -180,8 +180,7 @@ if ("sqlclient" -in $Install) {
     if ($ismacos) {
         brew tap microsoft/mssql-release https://github.com/Microsoft/homebrew-mssql-release
         #$null = brew update
-        $log = brew install microsoft/mssql-release/msodbcsql18 microsoft/mssql-release/mssql-tools18
-        $LASTEXITCODE = 0
+        $log = Invoke-Expression '& brew install microsoft/mssql-release/msodbcsql18 microsoft/mssql-release/mssql-tools18 || $true'
 
         echo "/opt/homebrew/bin" >> $env:GITHUB_PATH
     }

--- a/main.ps1
+++ b/main.ps1
@@ -180,7 +180,8 @@ if ("sqlclient" -in $Install) {
     if ($ismacos) {
         brew tap microsoft/mssql-release https://github.com/Microsoft/homebrew-mssql-release
         #$null = brew update
-        $log = brew install microsoft/mssql-release/msodbcsql18 microsoft/mssql-release/mssql-tools18 || true
+        $log = brew install microsoft/mssql-release/msodbcsql18 microsoft/mssql-release/mssql-tools18
+        $LASTEXITCODE = 0
 
         echo "/opt/homebrew/bin" >> $env:GITHUB_PATH
     }

--- a/main.ps1
+++ b/main.ps1
@@ -180,7 +180,7 @@ if ("sqlclient" -in $Install) {
     if ($ismacos) {
         brew tap microsoft/mssql-release https://github.com/Microsoft/homebrew-mssql-release
         #$null = brew update
-        $log = brew install microsoft/mssql-release/msodbcsql18 microsoft/mssql-release/mssql-tools18
+        $log = brew install microsoft/mssql-release/msodbcsql18 microsoft/mssql-release/mssql-tools18 || true
 
         echo "/opt/homebrew/bin" >> $env:GITHUB_PATH
     }

--- a/main.ps1
+++ b/main.ps1
@@ -180,7 +180,8 @@ if ("sqlclient" -in $Install) {
     if ($ismacos) {
         brew tap microsoft/mssql-release https://github.com/Microsoft/homebrew-mssql-release
         #$null = brew update
-        $log = Invoke-Expression '& brew install microsoft/mssql-release/msodbcsql18 microsoft/mssql-release/mssql-tools18 || $true'
+        brew uninstall sqlcmd
+        $log = brew install microsoft/mssql-release/msodbcsql18 microsoft/mssql-release/mssql-tools18
 
         echo "/opt/homebrew/bin" >> $env:GITHUB_PATH
     }

--- a/main.ps1
+++ b/main.ps1
@@ -9,6 +9,29 @@ param (
     [string]$Version = "2022"
 )
 
+# Install sqlcmd first to ensure it's available for any sa renaming operations
+Write-Output "Installing sqlcmd before proceeding with other installations"
+
+if ($islinux) {
+    Write-Output "Installing sqlcmd on Linux"
+    bash -c "curl -sSL https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -"
+    bash -c "curl https://packages.microsoft.com/config/ubuntu/\$(lsb_release -rs)/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list"
+    bash -c "sudo apt-get update"
+    bash -c "sudo ACCEPT_EULA=Y apt-get install -y sqlcmd"
+}
+
+if ($ismacos) {
+    Write-Output "Installing sqlcmd on macOS"
+    brew install sqlcmd
+}
+
+if ($iswindows) {
+    Write-Output "Installing sqlcmd on Windows"
+    choco install sqlcmd -y --no-progress
+}
+
+Write-Output "sqlcmd installation completed"
+
 if ("sqlengine" -in $Install) {
     Write-Output "Installing SQL Engine"
 


### PR DESCRIPTION
Adds support for specifying a custom admin username, improvements to the installation process, and updates to documentation. The most significant changes involve the addition of the `admin-username` input, enhancements to the `main.ps1` script for renaming the `sa` user, and updates to workflows and documentation to reflect the new functionality.