### PR TITLE
Add support for SQL Server 2025

### DIFF
--- a/.github/workflows/advanced.yml
+++ b/.github/workflows/advanced.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        version: ["2019", "2022", "2017", "2016"]
+        version: ["2025", "2019", "2022", "2017", "2016"]
         exclude:
             - os: ubuntu-latest
               version: "2017"
@@ -24,6 +24,8 @@ jobs:
               version: "2019"
             - os: macOS-latest
               version: "2022"
+            - os: macOS-latest
+              version: "2025"
 
     steps:
       - uses: actions/checkout@v4
@@ -53,6 +55,7 @@ jobs:
         uses: ./
         with:
           install: localdb
+          version: ${{ matrix.version }}
           show-log: true
 
       - name: Run sqlcmd

--- a/.github/workflows/simple.yml
+++ b/.github/workflows/simple.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        version: ["2019", "2022", "2017", "2016"]
+        version: ["2025", "2019", "2022", "2017", "2016"]
         exclude:
             - os: ubuntu-latest
               version: "2017"
@@ -22,6 +22,8 @@ jobs:
               version: "2019"
             - os: macOS-latest
               version: "2022"
+            - os: macOS-latest
+              version: "2025"
 
     steps:
       - uses: actions/checkout@v4

--- a/Dockerfile-2025
+++ b/Dockerfile-2025
@@ -1,0 +1,17 @@
+FROM mcr.microsoft.com/mssql/server:2025-latest
+
+USER root
+
+RUN apt-get update && \
+    apt-get install -yq gnupg gnupg2 gnupg1 curl apt-transport-https && \
+    curl https://packages.microsoft.com/keys/microsoft.asc -o /var/opt/mssql/ms-key.cer && \
+    apt-key add /var/opt/mssql/ms-key.cer && \
+    curl https://packages.microsoft.com/config/ubuntu/22.04/mssql-server-2025.list -o /etc/apt/sources.list.d/mssql-server-2025.list && \
+    apt-get update && \
+    apt-get install -y mssql-server-fts && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists
+
+EXPOSE 1433
+USER mssql
+ENTRYPOINT [ "/opt/mssql/bin/sqlservr" ]


### PR DESCRIPTION
Add support for SQL 2025.
LocalDB is out of scope - use 2022 for now and display a warning message 
Update workflows to add 2025 to the version matrix